### PR TITLE
feat: replace Nashorn engine with V8 engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ test {
 }
 
 dependencies {
-	implementation 'guru.nidi:graphviz-java:0.15.1'
+	implementation 'guru.nidi:graphviz-java-all-j2v8:0.15.1'
 	implementation 'ch.qos.logback:logback-classic:1.2.3'
 	implementation 'info.picocli:picocli:4.2.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'

--- a/src/main/java/com/javastreets/muleflowdiagrams/drawings/GraphDiagram.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/drawings/GraphDiagram.java
@@ -20,7 +20,7 @@ import com.javastreets.muleflowdiagrams.model.MuleComponent;
 import guru.nidi.graphviz.attribute.*;
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
-import guru.nidi.graphviz.engine.GraphvizJdkEngine;
+import guru.nidi.graphviz.engine.GraphvizV8Engine;
 import guru.nidi.graphviz.model.Factory;
 import guru.nidi.graphviz.model.MutableGraph;
 import guru.nidi.graphviz.model.MutableNode;
@@ -51,7 +51,7 @@ public class GraphDiagram implements Diagram {
         .addTo(graph);
     checkUnusedNodes(graph);
     try {
-      Graphviz.useEngine(new GraphvizJdkEngine());
+      Graphviz.useEngine(new GraphvizV8Engine());
       return Graphviz.fromGraph(graph).render(Format.PNG).toFile(drawingContext.getOutputFile())
           .exists();
     } catch (IOException e) {


### PR DESCRIPTION
Closes #26.  Nashorn engine is deprecated in JDK11 onwards.