### PR TITLE
Generate individual graph diagram for flows with -gs option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,12 @@
 = Mule Flow Diagrams
-:icons: font
+ifndef::env-github[:icons: font]
+ifdef::env-github[]
+:caution-caption: :fire:
+:important-caption: :exclamation:
+:note-caption: :paperclip:
+:tip-caption: :bulb:
+:warning-caption: :warning:
+endif::[]
 :toc: macro
 
 image:https://img.shields.io/github/release/manikmagar/mule-flow-diagrams.svg[Release,link=https://github.com/manikmagar/mule-flow-diagrams/releases]
@@ -21,25 +28,28 @@ If so, then try this `muleflowdiagrams` application. It can read your configurat
 [source, bash]
 ----
 $ muleflowdiagrams
-Missing required parameter: <sourcePath>
-Usage: muleflowdiagrams [-hV] [-d=<diagramType>] [-fl=<flowName>]
-						[-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
+Missing required parameter: '<sourcePath>'
+Usage: muleflowdiagrams [-hV] [-gs] [-d=<diagramType>] [-fl=<flowName>]
+                        [-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
 Create Flow diagrams from mule configuration files.
-	<sourcePath>   Source directory path containing mule configuration files
--d, --diagram=<diagramType>
-					Type of diagram to generate. Valid values: GRAPH, SEQUENCE
-					Default: GRAPH
-	-fl, --flowname=<flowName>
-					Target flow name to generate diagram for. All
-					flows/subflows not related to this flow will be excluded
-					from the diagram.
--h, --help         Show this help message and exit.
--o, --out=<outputFilename>
-					Name of the output file
-					Default: mule-diagram
--t, --target=<targetPath>
-					Output directory path to generate diagram
--V, --version      Print version information and exit.
+      <sourcePath>        Source directory path containing mule configuration
+                            files
+  -d, --diagram=<diagramType>
+                          Type of diagram to generate. Valid values: GRAPH,
+                            SEQUENCE
+                            Default: GRAPH
+      -fl, --flowname=<flowName>
+                          Target flow name to generate diagram for. All
+                            flows/subflows not related to this flow will be
+                            excluded from the diagram.
+      -gs, --genSingles   Generate individual diagrams for each flow.
+  -h, --help              Show this help message and exit.
+  -o, --out=<outputFilename>
+                          Name of the output file
+                            Default: mule-diagram
+  -t, --target=<targetPath>
+                          Output directory path to generate diagram
+  -V, --version           Print version information and exit.
 
 Copyright: 2020 Manik Magar, License: MIT
 Website: https://github.com/manikmagar/mule-flow-diagrams
@@ -187,25 +197,28 @@ Example:
 [source, bash]
 ----
 $ muleflowdiagrams
-Missing required parameter: <sourcePath>
-Usage: muleflowdiagrams [-hV] [-d=<diagramType>] [-fl=<flowName>]
-						[-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
+Missing required parameter: '<sourcePath>'
+Usage: muleflowdiagrams [-hV] [-gs] [-d=<diagramType>] [-fl=<flowName>]
+                        [-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
 Create Flow diagrams from mule configuration files.
-	<sourcePath>   Source directory path containing mule configuration files
--d, --diagram=<diagramType>
-					Type of diagram to generate. Valid values: GRAPH, SEQUENCE
-					Default: GRAPH
-	-fl, --flowname=<flowName>
-					Target flow name to generate diagram for. All
-					flows/subflows not related to this flow will be excluded
-					from the diagram.
--h, --help         Show this help message and exit.
--o, --out=<outputFilename>
-					Name of the output file
-					Default: mule-diagram
--t, --target=<targetPath>
-					Output directory path to generate diagram
--V, --version      Print version information and exit.
+      <sourcePath>        Source directory path containing mule configuration
+                            files
+  -d, --diagram=<diagramType>
+                          Type of diagram to generate. Valid values: GRAPH,
+                            SEQUENCE
+                            Default: GRAPH
+      -fl, --flowname=<flowName>
+                          Target flow name to generate diagram for. All
+                            flows/subflows not related to this flow will be
+                            excluded from the diagram.
+      -gs, --genSingles   Generate individual diagrams for each flow.
+  -h, --help              Show this help message and exit.
+  -o, --out=<outputFilename>
+                          Name of the output file
+                            Default: mule-diagram
+  -t, --target=<targetPath>
+                          Output directory path to generate diagram
+  -V, --version           Print version information and exit.
 
 Copyright: 2020 Manik Magar, License: MIT
 Website: https://github.com/manikmagar/mule-flow-diagrams
@@ -239,6 +252,13 @@ This argument value can be one of the following:
 ** Mule 3: All configurations from `src/main/app/` are scanned to generate a diagram.
 ** Mule 4: All configurations from `src/main/mule/` are scanned to generate a diagram.
 * Path to any non-mule project directory.
+
+=== Generate Individual flow diagrams
+When running against a large mule application, the generated `mule-diagram.png` can contain too many flows. To simplify understanding each flow, it can be helpful to generate diagrams per flow (not sub-flows).
+
+You can specify `-gs` or `--genSingles` option to generate individual flow diagrams, in addition to the consolidated one.
+
+These diagrams are generated at `{targetPath}/single-flow-diagrams/{currentDateTime}` directory. Each generated diagram has the same name as flow it represents.
 
 === Flowname
 If you just want to generate diagram for a single flow then specify it with `-fl` or `--flowname` option. This will exclude all flows and subflows that are not related to this target flow.

--- a/README.adoc
+++ b/README.adoc
@@ -30,26 +30,26 @@ If so, then try this `muleflowdiagrams` application. It can read your configurat
 $ muleflowdiagrams
 Missing required parameter: '<sourcePath>'
 Usage: muleflowdiagrams [-hV] [-gs] [-d=<diagramType>] [-fl=<flowName>]
-                        [-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
+						[-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
 Create Flow diagrams from mule configuration files.
-      <sourcePath>        Source directory path containing mule configuration
-                            files
-  -d, --diagram=<diagramType>
-                          Type of diagram to generate. Valid values: GRAPH,
-                            SEQUENCE
-                            Default: GRAPH
-      -fl, --flowname=<flowName>
-                          Target flow name to generate diagram for. All
-                            flows/subflows not related to this flow will be
-                            excluded from the diagram.
-      -gs, --genSingles   Generate individual diagrams for each flow.
-  -h, --help              Show this help message and exit.
-  -o, --out=<outputFilename>
-                          Name of the output file
-                            Default: mule-diagram
-  -t, --target=<targetPath>
-                          Output directory path to generate diagram
-  -V, --version           Print version information and exit.
+	<sourcePath>        Source directory path containing mule configuration
+							files
+-d, --diagram=<diagramType>
+						Type of diagram to generate. Valid values: GRAPH,
+							SEQUENCE
+							Default: GRAPH
+	-fl, --flowname=<flowName>
+						Target flow name to generate diagram for. All
+							flows/subflows not related to this flow will be
+							excluded from the diagram.
+	-gs, --genSingles   Generate individual diagrams for each flow.
+-h, --help              Show this help message and exit.
+-o, --out=<outputFilename>
+						Name of the output file
+							Default: mule-diagram
+-t, --target=<targetPath>
+						Output directory path to generate diagram
+-V, --version           Print version information and exit.
 
 Copyright: 2020 Manik Magar, License: MIT
 Website: https://github.com/manikmagar/mule-flow-diagrams
@@ -199,26 +199,26 @@ Example:
 $ muleflowdiagrams
 Missing required parameter: '<sourcePath>'
 Usage: muleflowdiagrams [-hV] [-gs] [-d=<diagramType>] [-fl=<flowName>]
-                        [-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
+						[-o=<outputFilename>] [-t=<targetPath>] <sourcePath>
 Create Flow diagrams from mule configuration files.
-      <sourcePath>        Source directory path containing mule configuration
-                            files
-  -d, --diagram=<diagramType>
-                          Type of diagram to generate. Valid values: GRAPH,
-                            SEQUENCE
-                            Default: GRAPH
-      -fl, --flowname=<flowName>
-                          Target flow name to generate diagram for. All
-                            flows/subflows not related to this flow will be
-                            excluded from the diagram.
-      -gs, --genSingles   Generate individual diagrams for each flow.
-  -h, --help              Show this help message and exit.
-  -o, --out=<outputFilename>
-                          Name of the output file
-                            Default: mule-diagram
-  -t, --target=<targetPath>
-                          Output directory path to generate diagram
-  -V, --version           Print version information and exit.
+	<sourcePath>        Source directory path containing mule configuration
+							files
+-d, --diagram=<diagramType>
+						Type of diagram to generate. Valid values: GRAPH,
+							SEQUENCE
+							Default: GRAPH
+	-fl, --flowname=<flowName>
+						Target flow name to generate diagram for. All
+							flows/subflows not related to this flow will be
+							excluded from the diagram.
+	-gs, --genSingles   Generate individual diagrams for each flow.
+-h, --help              Show this help message and exit.
+-o, --out=<outputFilename>
+						Name of the output file
+							Default: mule-diagram
+-t, --target=<targetPath>
+						Output directory path to generate diagram
+-V, --version           Print version information and exit.
 
 Copyright: 2020 Manik Magar, License: MIT
 Website: https://github.com/manikmagar/mule-flow-diagrams

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ test {
 dependencies {
 	implementation 'guru.nidi:graphviz-java-all-j2v8:0.16.0'
 	implementation 'ch.qos.logback:logback-classic:1.2.3'
-	implementation 'info.picocli:picocli:4.2.0'
+	implementation 'info.picocli:picocli:4.3.1'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
 	testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'

--- a/src/main/java/com/javastreets/muleflowdiagrams/DiagramRenderer.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/DiagramRenderer.java
@@ -172,6 +172,7 @@ public class DiagramRenderer {
     context.setDiagramType(model.getDiagramType());
     context.setOutputFile(new File(model.getTargetPath().toFile(), model.getOutputFilename()));
     context.setFlowName(model.getFlowName());
+    context.setGenerateSingles(model.isGenerateSingles());
     return context;
   }
 }

--- a/src/main/java/com/javastreets/muleflowdiagrams/app/Application.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/app/Application.java
@@ -14,6 +14,7 @@ import com.javastreets.muleflowdiagrams.util.FileUtil;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 @Command(name = "muleflowdiagrams", mixinStandardHelpOptions = true,
     versionProvider = VersionProvider.class,
@@ -27,21 +28,24 @@ public class Application implements Callable<Boolean> {
       description = "Source directory path containing mule configuration files")
   private Path sourcePath;
 
-  @CommandLine.Option(names = {"-t", "--target"},
-      description = "Output directory path to generate diagram")
+  @Option(names = {"-t", "--target"}, description = "Output directory path to generate diagram")
   private Path targetPath;
 
-  @CommandLine.Option(names = {"-d", "--diagram"}, defaultValue = "GRAPH",
+  @Option(names = {"-d", "--diagram"}, defaultValue = "GRAPH",
       description = "Type of diagram to generate. Valid values: ${COMPLETION-CANDIDATES}")
   private DiagramType diagramType;
 
-  @CommandLine.Option(names = {"-o", "--out"}, defaultValue = "mule-diagram",
+  @Option(names = {"-o", "--out"}, defaultValue = "mule-diagram",
       description = "Name of the output file")
   private String outputFilename;
 
-  @CommandLine.Option(names = {"-fl", "--flowname"},
+  @Option(names = {"-fl", "--flowname"},
       description = "Target flow name to generate diagram for. All flows/subflows not related to this flow will be excluded from the diagram.")
   private String flowName;
+
+  @Option(names = {"-gs", "--genSingles"}, defaultValue = "false",
+      description = "Generate individual diagrams for each flow.")
+  private boolean generateSingles;
 
   public static void main(String[] args) {
     int exitCode = new CommandLine(new Application()).execute(args);
@@ -61,6 +65,7 @@ public class Application implements Callable<Boolean> {
   CommandModel getCommandModel() {
     CommandModel cm = new CommandModel();
     cm.setSourcePath(sourcePath);
+    cm.setGenerateSingles(generateSingles);
     Path resolvedTarget = targetPath;
     if (targetPath == null) {
       if (Files.isDirectory(sourcePath))

--- a/src/main/java/com/javastreets/muleflowdiagrams/app/CommandModel.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/app/CommandModel.java
@@ -20,6 +20,8 @@ public class CommandModel {
 
   private String flowName;
 
+  private boolean generateSingles;
+
   private Integer muleVersion = 4;
 
   public String getFlowName() {
@@ -69,5 +71,13 @@ public class CommandModel {
 
   public void setDiagramType(DiagramType diagramType) {
     this.diagramType = diagramType;
+  }
+
+  public boolean isGenerateSingles() {
+    return generateSingles;
+  }
+
+  public void setGenerateSingles(boolean generateSingles) {
+    this.generateSingles = generateSingles;
   }
 }

--- a/src/main/java/com/javastreets/muleflowdiagrams/drawings/DrawingContext.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/drawings/DrawingContext.java
@@ -14,6 +14,7 @@ public class DrawingContext {
   private File outputFile;
   private Map<String, ComponentItem> knownComponents;
   private String flowName;
+  private boolean generateSingles;
 
   public String getFlowName() {
     return flowName;
@@ -53,5 +54,13 @@ public class DrawingContext {
 
   public void setKnownComponents(Map<String, ComponentItem> knownComponents) {
     this.knownComponents = Collections.unmodifiableMap(knownComponents);
+  }
+
+  public boolean isGenerateSingles() {
+    return generateSingles;
+  }
+
+  public void setGenerateSingles(boolean generateSingles) {
+    this.generateSingles = generateSingles;
   }
 }

--- a/src/main/java/com/javastreets/muleflowdiagrams/drawings/GraphDiagram.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/drawings/GraphDiagram.java
@@ -49,7 +49,7 @@ public class GraphDiagram implements Diagram {
             processComponent(component, flowGraph, drawingContext, flowRefs, mappedFlowKinds);
 
         flowNode.addTo(flowGraph);
-        if (drawingContext.isGenerateSingles()) {
+        if (drawingContext.isGenerateSingles() && component.isaFlow()) {
           writeFlowGraph(component, singleFlowDirPath, flowGraph);
         }
         flowGraph.addTo(rootGraph);
@@ -71,7 +71,7 @@ public class GraphDiagram implements Diagram {
       return false;
     String flowName = flowComponent.getName();
     Path targetPath = Paths.get(targetDirectory.toString(), flowName.concat(".png"));
-    log.info("Writing individual flow graph for {} at {}", flowName, targetPath.toString());
+    log.info("Writing individual flow graph for {} at {}", flowName, targetPath);
     try {
       flowGraph.setName(flowComponent.qualifiedName());
       Files.createDirectories(targetPath);

--- a/src/main/java/com/javastreets/muleflowdiagrams/util/DateUtil.java
+++ b/src/main/java/com/javastreets/muleflowdiagrams/util/DateUtil.java
@@ -10,9 +10,14 @@ public class DateUtil {
   }
 
   public static String now() {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss.SSS");
+    return now("dd-MMM-yyyy HH:mm:ss.SSS");
+  }
+
+  public static String now(String pattern) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
     LocalDateTime date = LocalDateTime.now();
     return date.format(formatter);
   }
+
 
 }

--- a/src/test/java/com/javastreets/muleflowdiagrams/DiagramRendererTest.java
+++ b/src/test/java/com/javastreets/muleflowdiagrams/DiagramRendererTest.java
@@ -100,10 +100,24 @@ class DiagramRendererTest {
     commandModel.setFlowName("test-flow");
     assertThat(new DiagramRenderer(commandModel).drawingContext(commandModel))
         .extracting(DrawingContext::getDiagramType, DrawingContext::getOutputFile,
-            DrawingContext::getFlowName)
+            DrawingContext::getFlowName, DrawingContext::isGenerateSingles)
         .containsExactly(DiagramType.GRAPH,
             new File(commandModel.getTargetPath().toFile(), commandModel.getOutputFilename()),
-            "test-flow");
+            "test-flow", false);
+  }
+
+  @Test
+  @DisplayName("Create drawing context from command model with single generation as true")
+  void toDrawingContextForSingles() {
+    CommandModel commandModel = getCommandModel();
+    commandModel.setFlowName("test-flow");
+    commandModel.setGenerateSingles(true);
+    assertThat(new DiagramRenderer(commandModel).drawingContext(commandModel))
+        .extracting(DrawingContext::getDiagramType, DrawingContext::getOutputFile,
+            DrawingContext::getFlowName, DrawingContext::isGenerateSingles)
+        .containsExactly(DiagramType.GRAPH,
+            new File(commandModel.getTargetPath().toFile(), commandModel.getOutputFilename()),
+            "test-flow", true);
   }
 
   @Test

--- a/src/test/java/com/javastreets/muleflowdiagrams/app/ApplicationTest.java
+++ b/src/test/java/com/javastreets/muleflowdiagrams/app/ApplicationTest.java
@@ -92,6 +92,7 @@ class ApplicationTest {
     expectedModel.setTargetPath(tempDir.toPath());
     expectedModel.setDiagramType(DiagramType.GRAPH);
     expectedModel.setOutputFilename("mule-diagram.png");
+    expectedModel.setGenerateSingles(false);
     assertThat(model).isEqualToComparingFieldByField(expectedModel);
   }
 
@@ -101,7 +102,7 @@ class ApplicationTest {
     Path source = Files.createDirectory(Paths.get(tempDir.getAbsolutePath(), "source"));
     Path target = Files.createDirectory(Paths.get(tempDir.getAbsolutePath(), "target"));
     String[] args = new String[] {source.toString(), "-t", target.toString(), "-o", "test", "-d",
-        "SEQUENCE", "-fl", "test-flow"};
+        "SEQUENCE", "-fl", "test-flow", "-gs"};
     Application application = new Application();
     new CommandLine(application).parseArgs(args);
     CommandModel model = application.getCommandModel();
@@ -112,6 +113,7 @@ class ApplicationTest {
     expectedModel.setDiagramType(DiagramType.SEQUENCE);
     expectedModel.setOutputFilename("test.png");
     expectedModel.setFlowName("test-flow");
+    expectedModel.setGenerateSingles(true);
     assertThat(model).isEqualToComparingFieldByField(expectedModel);
   }
 
@@ -141,7 +143,7 @@ class ApplicationTest {
     Path source = Files.createDirectory(Paths.get(tempDir.getAbsolutePath(), "source"));
     Path target = Files.createDirectory(Paths.get(tempDir.getAbsolutePath(), "target"));
     String[] args = new String[] {source.toString(), "--target", target.toString(), "--out", "test",
-        "--diagram", "SEQUENCE", "--flowname", "test-flow"};
+        "--diagram", "SEQUENCE", "--flowname", "test-flow", "--genSingles"};
     Application application = new Application();
     new CommandLine(application).parseArgs(args);
     CommandModel model = application.getCommandModel();
@@ -152,6 +154,7 @@ class ApplicationTest {
     expectedModel.setDiagramType(DiagramType.SEQUENCE);
     expectedModel.setOutputFilename("test.png");
     expectedModel.setFlowName("test-flow");
+    expectedModel.setGenerateSingles(true);
     assertThat(model).isEqualToComparingFieldByField(expectedModel);
   }
 }


### PR DESCRIPTION
When generating a graph for a large mule application, the diagram could look complicated. This PR introduces a new option `{"-gs", "genSingles"}` option to generate graph for individual flows too. It writes individual diagrams to `{targetPath}/single-flow-diagrams/{current-datetime}/` folder.